### PR TITLE
refactor: update modal window functionality

### DIFF
--- a/src/app/pages/question/question.component.html
+++ b/src/app/pages/question/question.component.html
@@ -23,4 +23,8 @@
   </app-ui-link>
 </div>
 <app-ui-spinner [show]="!!(isLoading$ | async)" />
-<app-ui-modal-window *ngIf="(modalWindowState$ | async)" (confirm)="handleModalResponse($event)" />
+<app-ui-modal-window 
+  *ngIf="(modalWindowState$ | async)" 
+  (confirm)="handleModalResponse($event)" 
+  [data]="(modalWindowData$ | async)!"
+/>

--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { ModalWindowModel } from './model/modal.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export default class ModalWindowService {
+  private item: ModalWindowModel = { page: '', text: '', title: '', link: '' };
+
+  getData(value: string): ModalWindowModel {
+    switch (value) {
+      case 'Go to catalog':
+      case 'Quizzes catalog':
+      case 'Go to catalog\n\n':
+        this.item.page = 'quizzes catalog';
+        this.item.link = 'quizzes-catalog';
+        break;
+      case '':
+        this.item.page = 'main page';
+        this.item.link = 'main';
+        break;
+      default:
+        this.item.page = value.toLowerCase();
+        this.item.link = value.toLowerCase();
+        break;
+    }
+
+    if (value.toLowerCase().includes('finish')) {
+      this.item = {
+        link: 'statistics',
+        page: 'statistics',
+        title: 'Finish quiz',
+        text: 'To get your quiz result, please, confirm this action and go to the page with the conclusion.',
+      };
+    } else {
+      this.item.title = 'Leave quiz';
+      this.item.text = 'Are you sure you want to exit and cancel the quiz? Your answers will not be saved.';
+    }
+    return this.item;
+  }
+}

--- a/src/app/services/model/modal.model.ts
+++ b/src/app/services/model/modal.model.ts
@@ -1,0 +1,6 @@
+export interface ModalWindowModel {
+    page: string;
+    title: string;
+    text: string;
+    link: string;
+}

--- a/src/app/ui-kit/components/modal-window/modal-window.component.html
+++ b/src/app/ui-kit/components/modal-window/modal-window.component.html
@@ -6,15 +6,14 @@
       <div
         class="relative transform overflow-hidden rounded-xl border-accent border-4 bg-bright text-left shadow-xl transition-all lg:max-w-lg max-md:max-w-sm p-10 flex flex-col items-center">
         <div class="flex flex-col items-center text-center w-full *:py-1.5">
-          <app-ui-typography type="H6">Leave quiz</app-ui-typography>
-          <app-ui-typography type="P1">Are you sure you want to exit and cancel the quiz? Your answers will not be
-            saved.</app-ui-typography>
+          <app-ui-typography type="H6">{{data.title}}</app-ui-typography>
+          <app-ui-typography type="P1">{{data.text}}</app-ui-typography>
           <div>
           </div>
         </div>
         <div class="flex max-md:flex-col items-center *:p-0.5">
           <app-ui-button (click)="onCancel()" type="accent">Back to quiz</app-ui-button>
-          <app-ui-button (click)="onConfirm()" class="*:text-accent" type="ghost">Go on main page</app-ui-button>
+          <app-ui-button (click)="onConfirm()" class="*:text-accent" type="ghost">Go to {{data.page}}</app-ui-button>
         </div>
       </div>
     </div>

--- a/src/app/ui-kit/components/modal-window/modal-window.component.ts
+++ b/src/app/ui-kit/components/modal-window/modal-window.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ModalWindowModel } from '../../../services/model/modal.model';
 
 @Component({
   selector: 'app-ui-modal-window',
@@ -6,7 +7,8 @@ import { Component, EventEmitter, Output } from '@angular/core';
 })
 export class ModalWindowComponent {
   @Output() confirm = new EventEmitter<boolean>();
-  
+  @Input() data: ModalWindowModel = { page: '', link: '', text: '', title: '' };
+
   onConfirm(): void {
     this.confirm.emit(true);
   }


### PR DESCRIPTION
## Links
[App](https://iryna-mertsalova.github.io/quiz-app)
[Ticket](https://trello.com/c/4o1GEPdx)

## Problem

- Bugs with the modal window 
- Missing name of clicked pages on modal window
- Unavailable functionality for finish quiz


## Solution

- Updating modal window bugs
- Adding logic to display selected page/link/button text
- Initializing functionality to complete the quiz and move to the statistics page