### PR TITLE
fix: update logic to get `checked` route and add refresh page functionctionality

### DIFF
--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -1,51 +1,75 @@
 import { Injectable } from '@angular/core';
 import { ModalWindowModel } from './model/modal.model';
 import { ModalRoutes } from '../utils/modal-routes.enum';
+import { DEFAULT_MODAL_DATA, MODAL_DATA } from '../utils/modal-data.constants';
+import { BehaviorSubject, map, Observable } from 'rxjs';
+import { Router } from '@angular/router';
+
+export interface ModalWindowState {
+  visibility: boolean;
+  choice: boolean;
+  data: ModalWindowModel;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalWindowService {
-  private item: ModalWindowModel = { page: '', text: '', title: '', link: '' };
+  modalState$ = new BehaviorSubject<ModalWindowState>({
+    visibility: false,
+    choice: false,
+    data: DEFAULT_MODAL_DATA,
+  });
 
-  getData(path: string): ModalWindowModel {
+  get modalWindowState$(): boolean {
+    return this.modalState$.getValue().visibility;
+  }
+
+  get modalWindowData$(): Observable<ModalWindowModel> {
+    return this.modalState$.asObservable().pipe(map(state => state.data));
+  }
+
+  constructor(private router: Router) {}
+
+  setModalData(path: string): ModalWindowModel {
     const updatedPath = path.trim();
-    switch (updatedPath) {
-      case ModalRoutes.QuizzesCatalog:
-        this.item.page = 'quizzes catalog';
-        this.item.link = 'quizzes-catalog';
-        break;
-      case ModalRoutes.Statistics:
-        this.item.page = 'statistics';
-        this.item.link = 'statistics';
-        break;
-      case ModalRoutes.Refresh: 
-        this.item.page = 'new quiz session';
-        break;
-      case '':
-        this.item.page = 'main page';
-        this.item.link = 'main';
-        break;
-      default:
-        this.item.page = updatedPath.toLowerCase();
-        this.item.link = updatedPath.toLowerCase();
-        break;
-    }
-      
-    if (updatedPath === ModalRoutes.Finish) {
-      this.item = {
-        link: 'statistics',
-        page: 'statistics',
-        title: 'Finish quiz',
-        text: 'To get your quiz result, please, confirm this action and go to the page with the conclusion.',
-      };
-    } else if (updatedPath == ModalRoutes.Refresh) {
-      this.item.title = 'Refresh page';
-      this.item.text = 'Do you want to refresh your quiz?\n Your current result will be lost'; 
+    return MODAL_DATA[updatedPath] || DEFAULT_MODAL_DATA;
+  }
+
+  setModalState(path: string): void {
+    const modalData = this.setModalData(path);
+    this.modalState$.next({
+      visibility: true,
+      choice: false,
+      data: modalData,
+    });
+  }
+
+  handleModalAction(confirm: boolean): void {
+    if (confirm) {
+      this.modalState$.next({
+        ...this.modalState$.getValue(),
+        choice: true,
+      });
+
+      const nextRoute = this.modalState$.getValue().data.link;
+      if (nextRoute === ModalRoutes.Refresh) {
+        window.location.reload();
+      } else if (nextRoute === ModalRoutes.Finish) {
+        this.router.navigateByUrl(ModalRoutes.Statistics);
+      } else {
+        this.router.navigateByUrl(nextRoute);
+      }
     } else {
-      this.item.title = 'Leave quiz';
-      this.item.text = 'Are you sure you want to exit and cancel the quiz? Your answers will not be saved.';
+      this.closeModal();
     }
-    return this.item;
+  }
+
+  closeModal(): void {
+    this.modalState$.next({
+      visibility: false,
+      choice: false,
+      data: DEFAULT_MODAL_DATA,
+    });
   }
 }

--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -11,10 +11,16 @@ export class ModalWindowService {
   getData(path: string): ModalWindowModel {
     const updatedPath = path.trim();
     switch (updatedPath) {
-      case ModalRoutes.ToCatalog:
       case ModalRoutes.QuizzesCatalog:
         this.item.page = 'quizzes catalog';
         this.item.link = 'quizzes-catalog';
+        break;
+      case ModalRoutes.Statistics:
+        this.item.page = 'statistics';
+        this.item.link = 'statistics';
+        break;
+      case ModalRoutes.Refresh: 
+        this.item.page = 'new quiz session';
         break;
       case '':
         this.item.page = 'main page';
@@ -25,14 +31,17 @@ export class ModalWindowService {
         this.item.link = updatedPath.toLowerCase();
         break;
     }
-
-    if (updatedPath.toLowerCase().includes('finish')) {
+      
+    if (updatedPath === ModalRoutes.Finish) {
       this.item = {
         link: 'statistics',
         page: 'statistics',
         title: 'Finish quiz',
         text: 'To get your quiz result, please, confirm this action and go to the page with the conclusion.',
       };
+    } else if (updatedPath == ModalRoutes.Refresh) {
+      this.item.title = 'Refresh page';
+      this.item.text = 'Do you want to refresh your quiz?\n Your current result will be lost'; 
     } else {
       this.item.title = 'Leave quiz';
       this.item.text = 'Are you sure you want to exit and cancel the quiz? Your answers will not be saved.';

--- a/src/app/ui-kit/layout/header/header.component.ts
+++ b/src/app/ui-kit/layout/header/header.component.ts
@@ -14,7 +14,7 @@ export class HeaderComponent implements OnInit {
 
   menuItems = [
     { link: 'quizzes-catalog', label: 'Quizzes catalog' },
-    { link: 'quiz', label: 'Quiz' },
+    { link: 'quiz/0', label: 'Quiz' },
     { link: 'statistics', label: 'Statistics' },
   ];
 

--- a/src/app/utils/decode-html.ts
+++ b/src/app/utils/decode-html.ts
@@ -1,5 +1,17 @@
-export function decodeText(html: string): string {
+import { QuestionModel } from '../services/model/question.model';
+
+function decodeText(html: string): string {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
   return doc.documentElement.textContent || html;
+}
+  
+export function decodeQuestion(question: QuestionModel): QuestionModel {
+  return {
+    ...question,
+    question: decodeText(question.question),
+    category: decodeText(question.category),
+    correct_answer: decodeText(question.correct_answer),
+    incorrect_answers: question.incorrect_answers.map(decodeText),
+  };
 }

--- a/src/app/utils/modal-data.constants.ts
+++ b/src/app/utils/modal-data.constants.ts
@@ -1,0 +1,39 @@
+import { ModalWindowModel } from '../services/model/modal.model';
+import { ModalRoutes } from './modal-routes.enum';
+
+export const DEFAULT_MODAL_DATA: ModalWindowModel = {
+  title: 'Leave quiz',
+  page: 'main page',
+  link: '/main',
+  text: 'Are you sure you want to exit and cancel the quiz? Your answers will not be saved.',
+};
+
+export const MODAL_DATA: Record<string, ModalWindowModel> = {
+  [ModalRoutes.QuizzesCatalog]: {
+    title: DEFAULT_MODAL_DATA.title,
+    text: DEFAULT_MODAL_DATA.text,
+    page: 'quizzes catalog',
+    link: '/quizzes-catalog',
+  },
+  [ModalRoutes.Statistics]: {
+    title: DEFAULT_MODAL_DATA.title,
+    text: DEFAULT_MODAL_DATA.text,
+    page: 'statistics',
+    link: '/statistics',
+  },
+  [ModalRoutes.Refresh]: {
+    page: 'new quiz session',
+    link: '',
+    title: 'Refresh page',
+    text: 'Do you want to refresh your quiz?\n Your current result will be lost',
+  },
+  [ModalRoutes.Finish]: {
+    page: 'statistics',
+    link: '/statistics',
+    title: 'Finish quiz',
+    text: 'To get your quiz result, please, confirm this action and go to the page with the conclusion.',
+  },
+  '': {
+    ...DEFAULT_MODAL_DATA,
+  },
+};

--- a/src/app/utils/modal-routes.enum.ts
+++ b/src/app/utils/modal-routes.enum.ts
@@ -1,5 +1,6 @@
 export enum ModalRoutes {
-    ToCatalog = 'Go to catalog',
-    QuizzesCatalog = 'Quizzes catalog',
-    Finish = 'Finish',   
+    Statistics = '/statistics',
+    QuizzesCatalog = '/quizzes-catalog',
+    Finish = '/finish',   
+    Refresh = 'refresh'
 }


### PR DESCRIPTION
## Links
[Trello](https://trello.com/c/mRUlMz7O)
[App](https://iryna-mertsalova.github.io/quiz-app)

## Problem

- Using `event` in the canDeactive guard
- Missing refreshing by browser

## Solution

- Updating code for guard in the question page
- Adding code to refresh the page in the browser and with keyboard combination
