### PR TITLE
feat: add unit-tests for components

### DIFF
--- a/src/app/ui-kit/components/button/buton.component.spec.ts
+++ b/src/app/ui-kit/components/button/buton.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ButtonComponent } from './button.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TypographyComponent } from '../typography/typography.component';
+
+describe('ButtonComponent', () => {
+  let fixture: ComponentFixture<ButtonComponent>;
+  let component: ButtonComponent;
+  let debugElement: DebugElement;
+
+  const testBtnText = 'Test Button Text';
+  const nextSmAccentBtnClasses = 'pr-3 py-1.5 bg-accent enabled:hover:bg-accent disabled:bg-secondary border-transparent';
+  const prevMdGhostBtnClasses = 'flex-row-reverse pl-3 py-3 border-accent enabled:hover:border-accent disabled:border-secondary';
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ ButtonComponent, TypographyComponent ],
+    }).compileComponents();
+  
+    fixture = TestBed.createComponent(ButtonComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set label with text', () => {
+    component.textType = 'P1';
+
+    fixture.nativeElement.querySelector('app-ui-typography')!.innerHTML = testBtnText;
+    fixture.detectChanges();
+  
+    const typographyElement = debugElement.query(By.directive(TypographyComponent));
+    
+    expect(typographyElement).toBeTruthy();
+    expect(typographyElement.nativeElement.textContent).toBe(testBtnText);
+  });
+
+  it('should render next-small-accent button with classes', () => {
+    component.iconState = 'next';
+    component.size = 'sm';
+    component.type = 'accent';
+    fixture.detectChanges();
+
+    expect(component.classes).toBe(nextSmAccentBtnClasses);
+  });
+
+  it('should render prev-medium-ghost button with classes', () => {
+    component.iconState = 'prev';
+    component.size = 'md';
+    component.type = 'ghost';
+    fixture.detectChanges();
+
+    expect(component.classes).toBe(prevMdGhostBtnClasses);
+  });
+
+  it('should render disabled button when disabled input is true', () => {
+    component.disabled = true;
+    fixture.detectChanges();
+
+    const buttonElement = debugElement.query(By.css('button'));
+    expect(buttonElement.nativeElement.disabled).toBeTruthy();
+  });
+});

--- a/src/app/ui-kit/components/button/button.component.spec.ts
+++ b/src/app/ui-kit/components/button/button.component.spec.ts
@@ -3,6 +3,8 @@ import { ButtonComponent } from './button.component';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { TypographyComponent } from '../typography/typography.component';
+import { AngularSvgIconModule } from 'angular-svg-icon';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ButtonComponent', () => {
   let fixture: ComponentFixture<ButtonComponent>;
@@ -16,6 +18,7 @@ describe('ButtonComponent', () => {
   beforeEach(async() => {
     await TestBed.configureTestingModule({
       declarations: [ ButtonComponent, TypographyComponent ],
+      imports: [ AngularSvgIconModule.forRoot(), HttpClientTestingModule ],
     }).compileComponents();
   
     fixture = TestBed.createComponent(ButtonComponent);

--- a/src/app/ui-kit/components/card-quiz/card-quiz.component.spec.ts
+++ b/src/app/ui-kit/components/card-quiz/card-quiz.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CardQuizComponent } from './card-quiz.component';
+import { DebugElement } from '@angular/core';
+import { TypographyComponent } from '../typography/typography.component';
+import { LinkComponent } from '../link/link.component';
+import { By } from '@angular/platform-browser';
+import { CategoryModel } from '../../../services/model/category.model';
+import { cardItemStyles } from '../../constants/card-item';
+import { AngularSvgIconModule } from 'angular-svg-icon';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { expect } from '@jest/globals';
+
+describe('CardQuizComponent', () => {
+  let fixture: ComponentFixture<CardQuizComponent>;
+  let component: CardQuizComponent;
+  let debugElement: DebugElement;
+
+  const testData: CategoryModel = {
+    id: 10,
+    name: 'Test Category',
+  };
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ CardQuizComponent, TypographyComponent, LinkComponent ],
+      imports: [ AngularSvgIconModule.forRoot(), HttpClientTestingModule ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CardQuizComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render component children and styles correctly', () => {
+    component.name = testData.name;
+    component.id = testData.id;
+    component.styles = cardItemStyles.accent;
+
+    fixture.detectChanges();
+    
+    const expectedHoverClass = component.styles.textColor === 'text-primary' 
+      ? 'hover:text-accent' 
+      : 'hover:text-warning';
+
+    const nameElement = debugElement.query(By.css('app-ui-typography[type="H6"]')).nativeElement;
+    const linkElement = debugElement.query(By.css('app-ui-link')).nativeElement;
+    const iconElement = debugElement.query(By.css('svg-icon')).nativeElement;
+
+    expect(nameElement.textContent).toBe(testData.name);
+    expect(nameElement.getAttribute('ng-reflect-class')).not.toStrictEqual([ component.styles.textColor, expectedHoverClass ]);
+    
+    expect(linkElement.getAttribute('ng-reflect-link')).toBe(`/quiz/${testData.id}`);
+    expect(iconElement.getAttribute('ng-reflect-src')).toBe(cardItemStyles.accent.icon);
+  });
+});

--- a/src/app/ui-kit/components/chart-rating/chart-rating.component.spec.ts
+++ b/src/app/ui-kit/components/chart-rating/chart-rating.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChartRatingComponent } from './chart-rating.component';
+import { DebugElement } from '@angular/core';
+import { CHART_DATA } from '../../../test-data/chart.data';
+import { ChartComponent, NgApexchartsModule } from 'ng-apexcharts';
+import { ChartOptions } from '../../constants/chart.options';
+import { ChartModel } from '../../../services/model/chart.modal';
+
+describe('ChartRatingComponent', () => {
+  let fixture: ComponentFixture<ChartRatingComponent>;
+  let component: ChartRatingComponent;
+  let debugElement: DebugElement;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ChartRatingComponent],
+      imports: [NgApexchartsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChartRatingComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should correctly initialize data', () => {
+    expect(component.chart).not.toBeNull();
+    expect(component.chartOptions).not.toBeNull();
+    expect(component.data).not.toBeNull();
+  });
+});

--- a/src/app/ui-kit/components/link/link.component.spec.ts
+++ b/src/app/ui-kit/components/link/link.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LinkComponent } from './link.component';
+import { Component, DebugElement } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  template: '<app-ui-link [link]="testLink">{{ testContent }}</app-ui-link>',
+})
+class TestHostComponent {
+  testLink: string = '/test-route';
+  testContent: string = 'test-content';
+}
+
+describe('LinkComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let debugElement: DebugElement;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ LinkComponent, TestHostComponent ],
+      imports: [RouterTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(hostComponent).toBeTruthy();
+  });
+
+  it('should create the verified content inside component', () => {
+    fixture.detectChanges();
+
+    const anchorElement = debugElement.query(By.css('a')).nativeElement;
+
+    expect(anchorElement.textContent.trim()).toBe(hostComponent.testContent);
+  });
+
+  it('should set the correct routerLink attribute', () => {
+    fixture.detectChanges();
+
+    const anchorElement = debugElement.query(By.css('a')).nativeElement;
+    
+    expect(anchorElement.getAttribute('ng-reflect-router-link')).toBe(
+      hostComponent.testLink,
+    );
+  });
+});

--- a/src/app/ui-kit/components/modal-window/modal-window.component.spec.ts
+++ b/src/app/ui-kit/components/modal-window/modal-window.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ModalWindowComponent } from './modal-window.component';
+import { DebugElement } from '@angular/core';
+import { ButtonComponent } from '../button/button.component';
+import { TypographyComponent } from '../typography/typography.component';
+import { By } from '@angular/platform-browser';
+import { ModalWindowModel } from '../../../services/model/modal.model';
+import { DEFAULT_MODAL_DATA } from '../../../utils/modal-data.constants';
+
+describe('ModalWindowComponent', () => {
+  let component: ModalWindowComponent;
+  let fixture: ComponentFixture<ModalWindowComponent>;
+  let debugElement: DebugElement;
+
+  const mockData: ModalWindowModel = DEFAULT_MODAL_DATA;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ ModalWindowComponent, ButtonComponent, TypographyComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ModalWindowComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render children of components', () => {
+    component.data = DEFAULT_MODAL_DATA;
+    fixture.detectChanges();
+
+    const titleElement = debugElement.query(By.css('app-ui-typography[type="H6"]')).nativeElement;
+    const textElement = debugElement.query(By.css('app-ui-typography[type="P1"]')).nativeElement;
+
+    expect(titleElement.textContent).toBe(DEFAULT_MODAL_DATA.title);
+    expect(textElement.textContent).toBe(DEFAULT_MODAL_DATA.text);
+  });
+
+  it('should emit correct values to confirm and cancel', () => {
+    const emitSpy = jest.spyOn(component.confirm, 'emit');
+
+    component.onConfirm();
+    expect(emitSpy).toHaveBeenCalledWith(true);
+
+    component.onCancel();
+    expect(emitSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('should handle button click events correctly', () => {
+    const confirmSpy = jest.spyOn(component, 'onConfirm');
+    const cancelSpy = jest.spyOn(component, 'onCancel');
+
+    component.data = DEFAULT_MODAL_DATA;
+    fixture.detectChanges();
+
+    const backBtn = debugElement.query(By.css('app-ui-button[type="accent"]'));
+    backBtn.triggerEventHandler('click', {});
+    expect(cancelSpy).toHaveBeenCalled();
+
+    const goToBtn = debugElement.query(By.css('app-ui-button[type="ghost"]'));
+    goToBtn.triggerEventHandler('click', {});
+    expect(confirmSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/ui-kit/components/notification/notification.component.spec.ts
+++ b/src/app/ui-kit/components/notification/notification.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotificationComponent } from './notification.component';
+import { DebugElement } from '@angular/core';
+import { TypographyComponent } from '../typography/typography.component';
+import { By } from '@angular/platform-browser';
+
+describe('NotificationComponent', () => {
+  let component: NotificationComponent;
+  let fixture: ComponentFixture<NotificationComponent>;
+  let debugElement: DebugElement;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ NotificationComponent, TypographyComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create the component and render text', () => {
+    expect(component).toBeTruthy();
+
+    const messageElement = debugElement.query(By.directive(TypographyComponent));
+    expect(messageElement.nativeElement.textContent.trim()).not.toBe(null);
+  });
+});

--- a/src/app/ui-kit/components/question-item/question-item.component.spec.ts
+++ b/src/app/ui-kit/components/question-item/question-item.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuestionItemComponent } from './question-item.component';
+import { DebugElement } from '@angular/core';
+import { TypographyComponent } from '../typography/typography.component';
+import { RadioGroupComponent } from '../radio-group/radio-group.component';
+import { ButtonComponent } from '../button/button.component';
+import { AngularSvgIconModule } from 'angular-svg-icon';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { QuestionModel } from '../../../services/model/question.model';
+import { By } from '@angular/platform-browser';
+import { expect } from '@jest/globals';
+import { RadioButtonComponent } from '../radio-group/radio-button/radio-button.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+describe('QuestionItemComponent', () => {
+  let fixture: ComponentFixture<QuestionItemComponent>;
+  let component: QuestionItemComponent;
+  let debugElement: DebugElement;
+
+  const testData: QuestionModel = {
+    type: true,
+    difficulty: 'easy',
+    category: 'Entertainment: Musicals &amp; Theatres',
+    question: 'How many plays is Shakespeare generally considered to have written?',
+    correct_answer: '37',
+    incorrect_answers: [ '18', '54', '25' ],
+  };
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ QuestionItemComponent, TypographyComponent, RadioGroupComponent, RadioButtonComponent, ButtonComponent ],
+      imports: [ AngularSvgIconModule.forRoot(), HttpClientTestingModule, ReactiveFormsModule, CommonModule ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuestionItemComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  function setData(): void {
+    component.item = testData;
+    component.options = [ ...testData.incorrect_answers, testData.correct_answer ];
+    fixture.detectChanges();
+  }
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set variables correctly', () => {
+    const formattedSpy = jest.spyOn(component, 'getFormattedText');
+    setData();
+    const itemElement = fixture.componentInstance;
+    
+    debugElement.triggerEventHandler('getFormattedText', {});
+    expect(formattedSpy).toHaveBeenCalled();
+    expect(formattedSpy).not.toBeNull();
+
+    expect(fixture.nativeElement).not.toBeNull();
+    expect(itemElement.item).toBe(testData);
+  });
+    
+  it('should handle selected answer', () => {
+    const selectedSpy = jest.spyOn(component, 'setSelectedAnswer');
+    setData();
+
+    const radioGroupElement = debugElement.query(By.directive(RadioGroupComponent));
+      
+    radioGroupElement.triggerEventHandler('getSelectedAnswer', testData.correct_answer);
+    expect(selectedSpy).toHaveBeenCalledWith(testData.correct_answer);
+  });
+
+  it('should emit prev and next events correctly', () => {
+    setData();
+    
+    component.radioGroup = { 
+      isSelectedAnswer: jest.fn(() => true), 
+    } as unknown as RadioGroupComponent;
+    
+    const prevEmitSpy = jest.spyOn(component.prev, 'emit');
+    const nextEmitSpy = jest.spyOn(component.next, 'emit');
+    
+    component.handlePrev();
+    component.handleNext();
+    
+    expect(component.radioGroup.isSelectedAnswer).toHaveBeenCalled();
+    expect(prevEmitSpy).toHaveBeenCalled();
+    expect(nextEmitSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/ui-kit/components/radio-group/radio-button/radio-button.component.spec.ts
+++ b/src/app/ui-kit/components/radio-group/radio-button/radio-button.component.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormControl } from '@angular/forms';
+import { RadioButtonComponent } from './radio-button.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TypographyComponent } from '../../typography/typography.component';
+
+describe('RadioButtonComponent', () => {
+  let component: RadioButtonComponent;
+  let fixture: ComponentFixture<RadioButtonComponent>;
+  let debugElement: DebugElement;
+
+  const testOption = 'test-option';
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ RadioButtonComponent, TypographyComponent ],
+      imports: [ReactiveFormsModule], 
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RadioButtonComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set attributes correctly', () => {
+    component.text = testOption;
+    component.control = new FormControl();
+    fixture.detectChanges();
+
+    const inputElement = debugElement.query(By.css('input[type=radio]')).nativeElement;
+    
+    expect(inputElement.getAttribute('id')).toBe(`radio-${testOption}`);
+    expect(inputElement.getAttribute('ng-reflect-value')).toBe(testOption);
+    expect(component.control instanceof FormControl).toBeTruthy();
+  });
+
+  it('click should change the FormControl value', () => {
+    component.control = new FormControl();
+    component.text = testOption;
+    fixture.detectChanges();
+
+    const inputElement: HTMLInputElement = debugElement.query(By.css('input')).nativeElement;
+    
+    expect(component.control.value).toBeNull(); 
+
+    inputElement.click(); 
+    fixture.detectChanges();
+
+    expect(component.control.value).toBe(testOption);
+  });
+
+  it('should set label with text', () => {
+    component.text = testOption;
+    component.control = new FormControl();
+    fixture.detectChanges();
+
+    const typographyElement = debugElement.query(By.directive(TypographyComponent)).nativeElement;
+
+    expect(typographyElement.textContent).toBe(testOption);
+  });
+});

--- a/src/app/ui-kit/components/radio-group/radio-group.component.spec.ts
+++ b/src/app/ui-kit/components/radio-group/radio-group.component.spec.ts
@@ -1,7 +1,6 @@
-import { Component, DebugElement } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RadioGroupComponent } from './radio-group.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { RadioButtonComponent } from './radio-button/radio-button.component';
 import { NotificationComponent } from '../notification/notification.component';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';

--- a/src/app/ui-kit/components/radio-group/radio-group.component.spec.ts
+++ b/src/app/ui-kit/components/radio-group/radio-group.component.spec.ts
@@ -1,0 +1,99 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RadioGroupComponent } from './radio-group.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RadioButtonComponent } from './radio-button/radio-button.component';
+import { NotificationComponent } from '../notification/notification.component';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TypographyComponent } from '../typography/typography.component';
+
+describe('RadioGroupComponent', () => {
+  let fixture: ComponentFixture<RadioGroupComponent>;
+  let component: RadioGroupComponent;
+  let debugElement: DebugElement;
+
+  const testOptions: string[] = [
+    'Option1', 'Option2', 'Option3', 'Option4',
+  ];
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ RadioGroupComponent, RadioButtonComponent, NotificationComponent, TypographyComponent ],
+      imports: [ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RadioGroupComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers(); 
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set radio buttons for each option', () => {
+    component.options = testOptions;
+    fixture.detectChanges();
+
+    const radioButtons = debugElement.queryAll(By.css('app-ui-radio-button'));
+    expect(radioButtons.length).toBe(testOptions.length);
+  });
+
+  it('should init valid form control', () => {
+    component.formControl = new FormControl('', Validators.required);
+
+    component.setFormControl = testOptions[0];
+    fixture.detectChanges();
+
+    expect(component.formControl.value).toBe(testOptions[0]);
+  });
+
+  it('should get selected value if user choose another option', () => {
+    jest.spyOn(component.getSelectedAnswer, 'emit');
+    component.options = testOptions;
+    component.setFormControl = testOptions[0];
+    fixture.detectChanges();
+
+    component.formControl.setValue(testOptions[1]);
+    fixture.detectChanges();
+
+    expect(component.getSelectedAnswer.emit).toHaveBeenCalledWith(testOptions[1]);
+  });
+
+  it('should show notification if user do not choose any option', (done) => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout'); 
+
+    component.options = testOptions;
+    fixture.detectChanges();
+
+    expect(component.isNotification$.value).toBe(false); 
+
+    expect(component.isSelectedAnswer()).toBe(false); 
+    expect(component.isNotification$.value).toBe(true); 
+
+    jest.advanceTimersByTime(1500);
+
+    expect(component.isNotification$.value).toBe(false);
+    done();
+    expect(setTimeout).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it('should not show notification if form is valid', () => {
+    component.options = testOptions;
+    component.setFormControl = testOptions[0];
+    fixture.detectChanges();
+
+    expect(component.isSelectedAnswer()).toBe(true); 
+    expect(component.isNotification$.value).toBe(false);
+  });
+});

--- a/src/app/ui-kit/components/spinner/spinner.component.spec.ts
+++ b/src/app/ui-kit/components/spinner/spinner.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SpinnerComponent } from './spinner.component';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TypographyComponent } from '../typography/typography.component';
+
+describe('SpinnerComponent', () => {
+  let component: SpinnerComponent;
+  let fixture: ComponentFixture<SpinnerComponent>;
+  let debugElement: DebugElement;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ SpinnerComponent, TypographyComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SpinnerComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render spinner and his children if show is true', () => {
+    component.show = true;
+    fixture.detectChanges();
+
+    const spinnerElement = debugElement.query(By.css('[role="status"]'));
+    const iconElement = debugElement.query(By.css('svg'));
+    const textElement = debugElement.query(By.directive(TypographyComponent));
+    
+    expect(spinnerElement).toBeTruthy();
+    expect(iconElement).toBeTruthy();
+    expect(textElement.nativeElement.textContent.trim()).toContain('Loading');
+  });
+
+  it('should not render spinner if show is false', () => {
+    component.show = false;
+    fixture.detectChanges();
+
+    const spinnerElement = debugElement.query(By.css('[role="status"]'));
+    expect(spinnerElement).toBeFalsy();
+  });
+});

--- a/src/app/ui-kit/components/statistic-card/statistic-card.component.spec.ts
+++ b/src/app/ui-kit/components/statistic-card/statistic-card.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StatisticCardComponent } from './statistic-card.component';
+import { DebugElement } from '@angular/core';
+import { TypographyComponent } from '../typography/typography.component';
+import { By } from '@angular/platform-browser';
+
+describe('StatisticCardComponent', () => {
+  let fixture: ComponentFixture<StatisticCardComponent>;
+  let component: StatisticCardComponent;
+  let debugElement: DebugElement;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ StatisticCardComponent, TypographyComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StatisticCardComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render text components correctly', () => {
+    debugElement.queryAll(By.directive(TypographyComponent)).map((item) => {
+      expect(item).toBeTruthy();
+      expect(item.nativeElement.textContent).not.toBeNull();
+    });
+  });
+});

--- a/src/app/ui-kit/components/typography/typography.component.spec.ts
+++ b/src/app/ui-kit/components/typography/typography.component.spec.ts
@@ -1,0 +1,53 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TextTypes, textTypesClasses } from '../../constants/text-types';
+import { TypographyComponent } from './typography.component';
+import { By } from '@angular/platform-browser';
+import { expect, jest, test } from '@jest/globals';
+
+@Component({
+  template: '<app-ui-typography [type]="testType" [highlightText]="testHighlight" >{{ testContent }}</app-ui-typography>',
+})
+class TestHostComponent {
+  testType: TextTypes = 'H6';
+  testContent: string = 'test-content';
+  testHighlight: string = 'framed';
+}
+
+describe('TypographyComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+  let debugElement: DebugElement; 
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ TypographyComponent, TestHostComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+  });
+
+  it('should create a component with not empty content', () => {
+    expect(hostComponent).toBeTruthy();
+    
+    const textElement = debugElement.query(By.css('app-ui-typography')).nativeElement;
+    expect(textElement.textContent).not.toBe(null);
+  });
+
+  it('should render correct HTML tag based on type input', () => {
+    Object.entries(textTypesClasses).forEach(([ typeKey, typeClasses ]) => {
+      hostComponent.testType = typeKey as TextTypes;
+      fixture.detectChanges();
+
+      const expectedTag = [ 'P1', 'P2', 'Label' ].includes(typeKey) ? 'p' : typeKey.toLowerCase();
+    
+      const element = debugElement.query(By.css(expectedTag));
+      
+      expect(element.nativeElement).toBeTruthy();
+      expect(element.nativeElement.tagName).toBe(expectedTag.toUpperCase());
+      expect(element.nativeElement.className).not.toStrictEqual(typeClasses);
+    });
+  });
+});

--- a/src/app/ui-kit/layout/header/header.component.spec.ts
+++ b/src/app/ui-kit/layout/header/header.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HeaderComponent } from './header.component';
+import { DebugElement, DestroyRef } from '@angular/core';
+import { LinkComponent } from '../../components/link/link.component';
+import { TypographyComponent } from '../../components/typography/typography.component';
+import { ButtonComponent } from '../../components/button/button.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
+
+describe('HeaderComponent', () => {
+  let fixture: ComponentFixture<HeaderComponent>;
+  let component: HeaderComponent;
+  let debugElement: DebugElement;
+  let router: Router;
+
+  beforeEach(async() => {
+    await TestBed.configureTestingModule({
+      declarations: [ HeaderComponent, LinkComponent, TypographyComponent, ButtonComponent ],
+      imports: [RouterTestingModule],
+      providers: [DestroyRef],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    debugElement = fixture.debugElement;
+    router = TestBed.inject(Router);
+  });
+
+  it('should create a component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize menu items and buttons in the template and data', () => {
+    fixture.detectChanges(); 
+
+    const menuItems = fixture.debugElement.queryAll(By.css('app-ui-link'));
+    const buttons = fixture.debugElement.queryAll(By.css('app-ui-button'));
+    
+    expect(menuItems.length).toBe(4);
+    expect(buttons).toBeTruthy();
+
+    expect(component.menuItems.length).toBe(3);
+    expect(component.isMenuOpen).toBe(false);
+  });
+
+  it('should open and close the mobile menu on click event', () => {
+    fixture.detectChanges();
+    
+    const button = fixture.debugElement.query(By.css('button[aria-label="Toggle navigation"]'));
+    button.triggerEventHandler('click', {});
+    expect(component.isMenuOpen).toBe(true);
+    
+    fixture.detectChanges();
+
+    button.triggerEventHandler('click', {});
+    expect(component.isMenuOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Links
[Trello](https://trello.com/c/uCrPMpdU)

## Problem

- Missing unit test for the smart and ui-kit components.


## Solution

- Adding jest unit-test for:

   - [x] Ui-kit components:
      - button
      - chart-rating
      - link
      - modal-window
      - notification
      - radio-group
      - radio-button
      - spinner
      - typography
      - header

   - [x] Smart components:
      - card-quiz
      - question-item
      - statistic-card