### PR TITLE
feat: add enum with support texts for statistics page and move subscription from setter to ngOnInit in the radio-group component

### DIFF
--- a/src/app/pages/question/question.component.ts
+++ b/src/app/pages/question/question.component.ts
@@ -21,6 +21,7 @@ import { decodeQuestion } from '../../utils/decode-html';
 import { TimeService } from '../../services/time.service';
 import { StatisticService } from '../../services/statistics.service';
 import { QuizResultModel } from '../../services/model/quiz-result.model';
+import { getStatisticText } from '../../utils/statistic-enums';
 
 @Component({
   standalone: true,
@@ -132,11 +133,12 @@ export class QuestionComponent implements OnInit {
   handleModalResponse(confirm: boolean): void {
     if (confirm === true && this.nextRoute === ModalRoutes.Finish) {
       const time: number = this.timeService.finishTest();
+      const score: number = this.statisticService.initScore(this.questions$, this.answers$.getValue());
       const result: QuizResultModel = {
         seconds: time,
         formattedTime: this.timeService.formatTime(time),
-        score: this.statisticService.initScore(this.questions$, this.answers$.getValue()),
-        resultText: 'Good try! Why not have another go? You might get a bigger score!',
+        score: score,
+        resultText: getStatisticText(score),
       };
       this.statisticService.initResult(result);
     }

--- a/src/app/pages/question/question.component.ts
+++ b/src/app/pages/question/question.component.ts
@@ -21,7 +21,7 @@ import { decodeQuestion } from '../../utils/decode-html';
 import { TimeService } from '../../services/time.service';
 import { StatisticService } from '../../services/statistics.service';
 import { QuizResultModel } from '../../services/model/quiz-result.model';
-import { getStatisticText } from '../../utils/statistic-enums';
+import { getStatisticText } from '../../utils/statistic-utils';
 
 @Component({
   standalone: true,

--- a/src/app/ui-kit/components/radio-group/radio-group.component.ts
+++ b/src/app/ui-kit/components/radio-group/radio-group.component.ts
@@ -1,25 +1,24 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-ui-radio-group',
   templateUrl: './radio-group.component.html',
 })
-export class RadioGroupComponent {
+export class RadioGroupComponent implements OnInit, OnDestroy {
   @Output() getSelectedAnswer = new EventEmitter<string>();
   @Input() options: string[] = [];
   @Input() set setFormControl(selectedAnswer: string) {
-    this.formControl.setValue(selectedAnswer);
-    this.formControl.valueChanges.subscribe((value) => {
-      this.getSelectedAnswer.emit(value);
-    });
+    this.formControl.setValue(selectedAnswer, { emitEvent: false });
   }
-  
+
+  private subscription!: Subscription;
+
   isNotification$ = new BehaviorSubject<boolean>(false);
   formControl: FormControl = new FormControl('', Validators.required);
   value: string | null = null;
-
+  
   isSelectedAnswer(): boolean {
     if (this.formControl.invalid) {
       this.isNotification$.next(true);
@@ -30,5 +29,17 @@ export class RadioGroupComponent {
       return false;
     }
     return true;
+  }
+
+  ngOnInit(): void {
+    this.subscription = this.formControl.valueChanges.subscribe((value) => {
+      this.getSelectedAnswer.emit(value);
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 }

--- a/src/app/utils/statistic-enums.ts
+++ b/src/app/utils/statistic-enums.ts
@@ -1,0 +1,23 @@
+export enum StatisticText {
+  Excellent = 'Amazing job! You mastered the test like a pro! 🎉',
+  VeryGood = 'Great work! You\'re doing very well. Keep it up! 💪',
+  Good = 'Good effort! You have solid knowledge. Keep learning! 📚',
+  Average = 'You\'re halfway there! A bit more effort and you\'ll shine. ✨',
+  Poor = 'It\'s a start! Review the material and try again. 🌱',
+}
+
+export function getStatisticText(score: number): StatisticText {
+  if (score === 10) {
+    return StatisticText.Excellent;
+  } 
+  if (score >= 8) {
+    return StatisticText.VeryGood;
+  } 
+  if (score >= 6) {
+    return StatisticText.Good;
+  } 
+  if (score >= 4) {
+    return StatisticText.Average;
+  } 
+  return StatisticText.Poor;
+}

--- a/src/app/utils/statistic-utils.ts
+++ b/src/app/utils/statistic-utils.ts
@@ -10,14 +10,18 @@ export function getStatisticText(score: number): StatisticText {
   if (score === 10) {
     return StatisticText.Excellent;
   } 
+
   if (score >= 8) {
     return StatisticText.VeryGood;
   } 
+
   if (score >= 6) {
     return StatisticText.Good;
-  } 
+  }
+
   if (score >= 4) {
     return StatisticText.Average;
-  } 
+  }
+   
   return StatisticText.Poor;
 }


### PR DESCRIPTION
## Links
[App](https://iryna-mertsalova.github.io/quiz-app/)
[Trello ticket #1](https://trello.com/c/PoMPOEKp)
[Trello ticket #2](https://trello.com/c/ZUjf1RHO)

## Problem

- Missing support text for the statistics page to identify the user's score
- Subscription to the `valueChanges` observable of the `formControl` is the setter method `setFormControl`

## Solution

- Adding an enum with support text
- Creating a function that returns correct text according to getting the score
- Moving the subscription to the `valueChanges` observable to the `ngOnInit` lifecycle hook, where it is safer to manage subscriptions